### PR TITLE
Added missing lib config to tsconfig.spec (#1)

### DIFF
--- a/src/tsconfig.spec.json
+++ b/src/tsconfig.spec.json
@@ -1,9 +1,9 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
     "allowJs": true,
     "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "lib": ["es2018"]
+    "experimentalDecorators": true
   }
 }

--- a/src/tsconfig.spec.json
+++ b/src/tsconfig.spec.json
@@ -3,6 +3,7 @@
     "module": "commonjs",
     "allowJs": true,
     "emitDecoratorMetadata": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "lib": ["es2018"]
   }
 }


### PR DESCRIPTION
Without `"lib": ["es2018"]` in ``tsconfig.spec` -> `compilerOptions` test using `Promise` or `async` would eventually break.

See [https://github.com/thymikee/jest-preset-angular/issues/225](https://github.com/thymikee/jest-preset-angular/issues/225)